### PR TITLE
Signature verification failed when notification message contains multibyte character

### DIFF
--- a/lib/snsclient.js
+++ b/lib/snsclient.js
@@ -58,7 +58,7 @@ function validateMessage(pem, message, cb) {
     if(!msg) return cb(new Error('Invalid request'));
 
     var verifier = crypto.createVerify('RSA-SHA1');
-    verifier.update(msg);
+    verifier.update(msg, 'utf8');
     return (verifier.verify(pem, message.Signature, 'base64')
         ? cb()
         : cb(new Error('Invalid request')));


### PR DESCRIPTION
Signature verification in validateMessage() failed when notification message contains multibyte character like Japanese Kanji, because default encoding of Verify.update() is 'binary' not 'utf8'. 

https://github.com/joyent/node/blob/master/src/node_crypto.cc#L3513
https://github.com/joyent/node/blob/master/src/node.h#L132

To fix this, set encoding to 'utf8' explicitly using second argument of Verify.update().
