### PR TITLE
Report Subscription Confirmation

### DIFF
--- a/lib/snsclient.js
+++ b/lib/snsclient.js
@@ -1,6 +1,7 @@
 var https = require('https')
   , crypto = require('crypto')
-  , url = require('url');
+  , url = require('url')
+  , xml2js = require('xml2js');
 
 // Local memory cache for PEM certificates
 var pem_cache = {};
@@ -127,6 +128,20 @@ function SNSClient(opts, cb) {
                         if (req.statusCode != 200) {
                             return cb(new Error('Error confirming subscription'));
                         }
+                        var response = '';
+                        req.on('data', function(chunk) {
+                            response += chunk;
+                        });
+                        req.on('end', function() {
+                            var parser = new xml2js.Parser();
+                            parser.addListener('end', function(result) {
+                                if (typeof result != 'undefined' && typeof result.Errors != 'undefined') {
+                                    cb(new Error('Error parsing subscription confirmation response XML'));
+                                }
+                                return cb(null, result);
+                            });
+                            parser.parseString(response);
+                        });
                     });
                 }
                 if(message.Type === 'Notification') {

--- a/lib/snsclient.js
+++ b/lib/snsclient.js
@@ -123,7 +123,11 @@ function SNSClient(opts, cb) {
             validateRequest(opts, message, function(err){
                 if(err) return;
                 if(message.Type === 'SubscriptionConfirmation') {
-                    return https.get(url.parse(message.SubscribeURL));
+                    https.get(url.parse(message.SubscribeURL), function(req) {
+                        if (req.statusCode != 200) {
+                            return cb(new Error('Error confirming subscription'));
+                        }
+                    });
                 }
                 if(message.Type === 'Notification') {
                     return cb(null, message);


### PR DESCRIPTION
This branch reports the subscription confirmation message to the client callback. The only way to get the subscription ARN, used for modifying a subscription, is by parsing the confirmation message.
