### PR TITLE
Pass Through the Error from the Request Validation to Callback

### DIFF
--- a/lib/snsclient.js
+++ b/lib/snsclient.js
@@ -121,7 +121,9 @@ function SNSClient(opts, cb) {
                 return cb(new Error('Error parsing JSON'));
             }
             validateRequest(opts, message, function(err){
-                if(err) return;
+                if(err) {
+                    return cb(err);
+                }
                 if(message.Type === 'SubscriptionConfirmation') {
                     return https.get(url.parse(message.SubscribeURL));
                 }


### PR DESCRIPTION
Currently if the validateRequest method returns an error, the callback function is not called.  This passes the error through to the callback.
