### PR TITLE
Allow message to be passed in directly

### DIFF
--- a/lib/snsclient.js
+++ b/lib/snsclient.js
@@ -114,7 +114,6 @@ function SNSClient(opts, cb) {
                 return cb(err);
             }
             if(message.Type === 'SubscriptionConfirmation') {
-                // broken?
                 return https.get(url.parse(message.SubscribeURL));
             }
             if(message.Type === 'Notification') {

--- a/lib/snsclient.js
+++ b/lib/snsclient.js
@@ -107,6 +107,26 @@ function SNSClient(opts, cb) {
         cb = opts;
         opts = {};
     }
+
+    var handleMessage = function(message) {
+        validateRequest(opts, message, function(err){
+            if(err) {
+                return cb(err);
+            }
+            if(message.Type === 'SubscriptionConfirmation') {
+                // broken?
+                return https.get(url.parse(message.SubscribeURL));
+            }
+            if(message.Type === 'Notification') {
+                return cb(null, message);
+            }
+        });
+    };
+
+    if (opts.message) {
+        return handleMessage(opts.message);
+    }
+
     return function SNSClient(req, res) {
         var chunks = [];
         req.on('data', function(chunk) {
@@ -120,17 +140,7 @@ function SNSClient(opts, cb) {
                 // catch a JSON parsing error
                 return cb(new Error('Error parsing JSON'));
             }
-            validateRequest(opts, message, function(err){
-                if(err) {
-                    return cb(err);
-                }
-                if(message.Type === 'SubscriptionConfirmation') {
-                    return https.get(url.parse(message.SubscribeURL));
-                }
-                if(message.Type === 'Notification') {
-                    return cb(null, message);
-                }
-            });
+            handleMessage(message, cb);
         });
         // end the request always before doing anything with the request.
         // There isn't any reason to let it hang.

--- a/lib/snsclient.js
+++ b/lib/snsclient.js
@@ -37,6 +37,10 @@ function validateRequest(opts, message, cb) {
         return validateMessage(pem, message, cb);
     } else {
         https.get(cert, function(res) {
+            if (res.statusCode != 200) {
+                return cb(new Error('Could not load certificate'));
+            }
+
             var chunks = [];
             res.on('data', function(chunk) {
                 chunks.push(chunk);
@@ -49,6 +53,8 @@ function validateRequest(opts, message, cb) {
             res.on('error', function() {
                 return cb(new Error('Could not download certificate.'));
             });
+        }).on('error', function(e) {
+            return cb(e);
         });
     }
 }


### PR DESCRIPTION
In my usage I'd like to be able to pass a full message into snsclient rather than having this library parse the message off of the request. This pull request allows you to pass the message in on the `opts` object and bypass the request handling.

Let me know if this API addition looks ok, or if you'd rather do it some other way.
