### PR TITLE
Optional callback on SubscriptionConfirmation

### DIFF
--- a/lib/snsclient.js
+++ b/lib/snsclient.js
@@ -125,7 +125,13 @@ function SNSClient(opts, cb) {
                     return cb(err);
                 }
                 if(message.Type === 'SubscriptionConfirmation') {
-                    return https.get(url.parse(message.SubscribeURL));
+                    https.get(url.parse(message.SubscribeURL), function(res) {
+                      if(opts.confirmation) { // return SubscriptionConfirmation if needed
+                        cb(null, message);
+                      }
+                    }).on('error', function(err2) {
+                      cb(err2);
+                    });
                 }
                 if(message.Type === 'Notification') {
                     return cb(null, message);

--- a/lib/snsclient.js
+++ b/lib/snsclient.js
@@ -125,7 +125,7 @@ function SNSClient(opts, cb) {
                     return cb(err);
                 }
                 if(message.Type === 'SubscriptionConfirmation') {
-                    https.get(url.parse(message.SubscribeURL), function(res) {
+                    return https.get(url.parse(message.SubscribeURL), function(res) {
                       if(opts.confirmation) { // return SubscriptionConfirmation if needed
                         cb(null, message);
                       }


### PR DESCRIPTION
Hi Matt,
this change will leave the leave the interface as is only if opts.confirmation is true the callback will be called as well for SubscriptionConfirmation.

This is handy if you want to install a on-exit handler to unsubscribe to SNS.

Regards
Kai
