### PR TITLE
use already parsed body if available

### DIFF
--- a/lib/snsclient.js
+++ b/lib/snsclient.js
@@ -101,6 +101,26 @@ function buildSignatureString(message) {
     return chunks.join('\n')+'\n';
 }
 
+function readMessage(req, cb) {
+    // maybe all the work was already done
+    if(typeof req.body == 'object')
+	return cb(null, req.body);
+    var chunks = [];
+    req.on('data', function(chunk) {
+        chunks.push(chunk);
+    });
+    req.on('end', function() {
+        var message;
+        try {
+            message = JSON.parse(chunks.join(''));
+        } catch(e) {
+            // catch a JSON parsing error
+            return cb(new Error('Error parsing JSON'));
+        }
+	return cb(null, message);
+    });
+}
+
 function SNSClient(opts, cb) {
     // opts is entirely optional, but cb is not
     if(typeof opts === 'function') {
@@ -108,18 +128,8 @@ function SNSClient(opts, cb) {
         opts = {};
     }
     return function SNSClient(req, res) {
-        var chunks = [];
-        req.on('data', function(chunk) {
-            chunks.push(chunk);
-        });
-        req.on('end', function() {
-            var message;
-            try {
-                message = JSON.parse(chunks.join(''));
-            } catch(e) {
-                // catch a JSON parsing error
-                return cb(new Error('Error parsing JSON'));
-            }
+        readMessage(req, function(err, message) {
+	    if(err) return cb(err);
             validateRequest(opts, message, function(err){
                 if(err) {
                     return cb(err);


### PR DESCRIPTION
sometimes when using express or a framework based on it (eg sails), the message body may already be parsed by a previous middleware (that the user may not control - depending on the framework). This allows that case to work - without affecting anything else.
