### PR TITLE
Support http and https subscription confirmations

### DIFF
--- a/lib/snsclient.js
+++ b/lib/snsclient.js
@@ -1,4 +1,5 @@
 var https = require('https')
+  , http = require('http')
   , crypto = require('crypto')
   , url = require('url');
 
@@ -22,7 +23,7 @@ function validateRequest(opts, message, cb) {
 
     var cert = url.parse(message.SigningCertURL)
       , arn = message.TopicArn.split(':');
-    
+
     // TopicArn Format:  arn:aws:sns:{{ region }}:{{ account }}:{{ topic }}
     if(opts.region  && opts.region  !== arn[3]) return cb(new Error('Invalid request'));
     if(opts.account && opts.account !== arn[4]) return cb(new Error('Invalid request'));
@@ -120,12 +121,19 @@ function SNSClient(opts, cb) {
                 // catch a JSON parsing error
                 return cb(new Error('Error parsing JSON'));
             }
-            validateRequest(opts, message, function(err){
+            validateRequest(opts, message, function(err) {
                 if(err) {
                     return cb(err);
                 }
                 if(message.Type === 'SubscriptionConfirmation') {
-                    return https.get(url.parse(message.SubscribeURL));
+                    var parts = url.parse(message.SubscribeURL);
+
+                    // support http and https
+                    if(parts.protocol === 'http:') {
+                        return http.get(parts);
+                    }
+
+                    return https.get(parts);
                 }
                 if(message.Type === 'Notification') {
                     return cb(null, message);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "aws-snsclient",
   "description": "A client for parsing Amazon AWS SNS requests.",
   "keywords": ["amazon", "aws", "sns", "client"],
-  "version": "0.2.0",
+  "version": "0.2.1",
   "repository": "git://github.com/mattrobenolt/node-snsclient.git",
   "author": "Matt Robenolt <matt@ydekproductions.com> (http://mattrobenolt.com)",
   "main": "./index",


### PR DESCRIPTION
We use Comcast's [CMB](https://github.com/Comcast/cmb) (Cloud Message Bus) for local development of SQS and SNS and out of the box it runs over http not https so I've added a check of the SubscribeURL to switch between http and https confirmations.
